### PR TITLE
add imagePullSecrets to deployment templates

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         {{- include "opal.clientLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: opal-client
           image: {{ printf "%s/authorizon/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         {{- include "opal.serverLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.e2e }}
       volumes:
         - name: e2e

--- a/test/linter/values-entries.yaml
+++ b/test/linter/values-entries.yaml
@@ -1,4 +1,6 @@
 imageRegistry: docker.io
+imagePullSecrets: 
+  - name: my_awesome_secret
 
 server:
   dataConfigSources:

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,5 @@
 imageRegistry: docker.io
+imagePullSecrets: []
 
 server:
   port: 7002


### PR DESCRIPTION
As mentioned in issue #5 we cannot use custom docker credentials (e.g. for private registries).

This PR aim to solve this.