### PR TITLE
Use custom name and path for client/server images + custom imagePullPolicy

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         {{- include "opal.clientLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: opal-client
           image: {{ printf "%s/authorizon/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}

--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -22,8 +22,8 @@ spec:
       {{- end }}
       containers:
         - name: opal-client
-          image: {{ printf "%s/authorizon/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.imageRegistry }}{{ .Values.client.image.path }}{{ .Values.client.image.name }}:{{ .Values.client.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.client.port }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         {{- include "opal.serverLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.e2e }}
       volumes:
         - name: e2e

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -31,8 +31,8 @@ spec:
 
       initContainers:
         - name: git-init
-          image: {{ printf "%s/authorizon/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.imageRegistry }}{{ .Values.server.image.path }}{{ .Values.server.image.name }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
             - mountPath: /opt/e2e
               name: e2e
@@ -60,8 +60,8 @@ spec:
       {{- end }}
       containers:
         - name: opal-server
-          image: {{ printf "%s/authorizon/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.imageRegistry }}{{ .Values.server.image.path }}{{ .Values.server.image.name }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if .Values.e2e }}
           volumeMounts:
             - mountPath: /opt/e2e/policy-repo-data

--- a/test/linter/values-entries.yaml
+++ b/test/linter/values-entries.yaml
@@ -1,4 +1,6 @@
 imageRegistry: docker.io
+imagePullSecrets: 
+  - name: my_awesome_secret
 
 server:
   dataConfigSources:

--- a/values.schema.json
+++ b/values.schema.json
@@ -34,6 +34,21 @@
       "type": ["null", "object"], "additionalProperties": false, "title": "opal server settings",
       "required": ["port", "policyRepoUrl", "pollingInterval", "dataConfigSources", "broadcastPgsql", "uvicornWorkers", "replicas"],
       "properties": {
+        "image": {
+          "type": ["null", "object"], "additionalProperties": false, "title": "opal-server image settings",
+          "required": ["path", "name"],
+          "properties": {
+            "path": {
+              "type": "string", "title": "opal-server path to image", "default": "/authorizon/"
+            },
+            "name": {
+              "type": "string", "title": "opal-server image name", "default": "opal-server"
+            },
+            "tag": {
+              "type": "string", "title": "opal-server image tag", "default": "0.1.8"
+            }
+          }
+        },
         "port": {
           "type": "integer", "title": "server listening port", "default": 7002
         },
@@ -63,6 +78,21 @@
       "type": ["null", "object"], "additionalProperties": false, "title": "opal client settings",
       "required": ["port", "opaPort", "replicas"],
       "properties": {
+        "image": {
+          "type": ["null", "object"], "additionalProperties": false, "title": "opal-client image settings",
+            "required": ["path", "name"],
+          "properties": {
+            "path": {
+              "type": "string", "title": "opal-client path to image", "default": "/authorizon/"
+            },
+            "name": {
+              "type": "string", "title": "opal-client image name", "default": "opal-client"
+            },
+            "tag": {
+              "type": "string", "title": "opal-client image tag", "default": "0.1.8"
+            }
+          }
+        },
         "port": {
           "type": "integer", "title": "client rest port", "default": 7000
         },

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,13 @@
+imagePullPolicy: IfNotPresent
 imageRegistry: docker.io
 imagePullSecrets: []
 
 server:
+  image:
+    path: /authorizon/
+    name: opal-server
+    # overrides server image tag, default is chart appVersion
+    tag: ""
   port: 7002
   policyRepoUrl: "https://github.com/authorizon/opal-example-policy-repo"
   pollingInterval: 30
@@ -14,6 +20,11 @@ server:
   replicas: 1
 
 client:
+  image:
+    path: /authorizon/
+    name: opal-client
+    # overrides client image tag, default is chart appVersion
+    tag: ""
   port: 7000
   opaPort: 8181
   replicas: 1

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,5 @@
 imageRegistry: docker.io
+imagePullSecrets: []
 
 server:
   port: 7002


### PR DESCRIPTION
As i wrote in issue #6 some values (as image path and name) are hardcoded in deployment templates.

I added objects in server and client values to split the initial image variable to use keys from these objects.

Hope this will do the trick.