### PR TITLE
Use custom name and path for client/server images + custom imagePullPolicy

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -18,8 +18,8 @@ spec:
     spec:
       containers:
         - name: opal-client
-          image: {{ printf "%s/authorizon/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.imageRegistry }}{{ .Values.client.image.path }}{{ .Values.client.image.name }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.client.port }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -27,8 +27,8 @@ spec:
 
       initContainers:
         - name: git-init
-          image: {{ printf "%s/authorizon/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.imageRegistry }}{{ .Values.server.image.path }}{{ .Values.server.image.name }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
             - mountPath: /opt/e2e
               name: e2e
@@ -56,8 +56,8 @@ spec:
       {{- end }}
       containers:
         - name: opal-server
-          image: {{ printf "%s/authorizon/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.imageRegistry }}{{ .Values.server.image.path }}{{ .Values.server.image.name }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if .Values.e2e }}
           volumeMounts:
             - mountPath: /opt/e2e/policy-repo-data

--- a/values.schema.json
+++ b/values.schema.json
@@ -34,6 +34,18 @@
       "type": ["null", "object"], "additionalProperties": false, "title": "opal server settings",
       "required": ["port", "policyRepoUrl", "pollingInterval", "dataConfigSources", "broadcastPgsql", "uvicornWorkers", "replicas"],
       "properties": {
+        "image": {
+          "type": ["null", "object"], "additionalProperties": false, "title": "opal-server image settings",
+          "required": ["path", "name"],
+          "properties": {
+            "path": {
+              "type": "string", "title": "opal-server path to image", "default": "/authorizon/"
+            },
+            "name": {
+              "type": "string", "title": "opal-server image name", "default": "opal-server"
+            }
+          }
+        },
         "port": {
           "type": "integer", "title": "server listening port", "default": 7002
         },
@@ -63,6 +75,18 @@
       "type": ["null", "object"], "additionalProperties": false, "title": "opal client settings",
       "required": ["port", "opaPort", "replicas"],
       "properties": {
+        "image": {
+          "type": ["null", "object"], "additionalProperties": false, "title": "opal-client image settings",
+            "required": ["path", "name"],
+          "properties": {
+            "path": {
+              "type": "string", "title": "opal-client path to image", "default": "/authorizon/"
+            },
+            "name": {
+              "type": "string", "title": "opal-client image name", "default": "opal-client"
+            }
+          }
+        },
         "port": {
           "type": "integer", "title": "client rest port", "default": 7000
         },

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,10 @@
+imagePullPolicy: IfNotPresent
 imageRegistry: docker.io
 
 server:
+  image:
+    path: /authorizon/
+    name: opal-server
   port: 7002
   policyRepoUrl: "https://github.com/authorizon/opal-example-policy-repo"
   pollingInterval: 30
@@ -13,6 +17,9 @@ server:
   replicas: 1
 
 client:
+  image:
+    path: /authorizon/
+    name: opal-client
   port: 7000
   opaPort: 8181
   replicas: 1


### PR DESCRIPTION
As i wrote in issue #6 some values (as image path and name) are hardcoded in deployment templates.

I added objects in server and client values to split the initial image variable to use keys from these objects.

Hope this will do the trick.