### PR TITLE
Add prerelease extension to chart's kubeVersion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ type: application
 icon: https://www.opal.ac/icons/icon-192x192.png
 version: 0.0.0 # actual chart version is managed by git tags
 appVersion: 0.1.18
-kubeVersion: ">= 1.18.0"
+kubeVersion: ">= 1.18.0-0"


### PR DESCRIPTION
Hello, I'm adding a prerelease suffix to the minimum `kubeVersion` to avoid errors when deploying to an AWS EKS cluster:

```bash
$ helm upgrade -i --create-namespace -n ckreiling-opal-experiment experiment opal/opal -f values.yaml
Release "experiment" does not exist. Installing it now.
Error: chart requires kubeVersion: >= 1.18.0 which is incompatible with Kubernetes v1.21.5-eks-bc4871b
```

EKS uses the prerelease suffix to specify what appears to be the EKS version.