### PR TITLE
Docker image repository change

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,5 +3,5 @@ name: opal
 type: application
 icon: https://www.opal.ac/icons/icon-192x192.png
 version: 0.0.0 # actual chart version is managed by git tags
-appVersion: 0.1.18
+appVersion: 0.3.1
 kubeVersion: ">= 1.18.0"

--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
         - name: opal-client
-          image: {{ printf "%s/authorizon/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
+          image: {{ printf "%s/permitio/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -31,7 +31,7 @@ spec:
 
       initContainers:
         - name: git-init
-          image: {{ printf "%s/authorizon/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
+          image: {{ printf "%s/permitio/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /opt/e2e
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       containers:
         - name: opal-server
-          image: {{ printf "%s/authorizon/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
+          image: {{ printf "%s/permitio/opal-server:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
           imagePullPolicy: IfNotPresent
           {{- if .Values.e2e }}
           volumeMounts:


### PR DESCRIPTION
The docker images pulled from authorizon repository (version: 0.1.18) were not getting initialised properly when container's securityContext was set to run as _nonRoot_ user -  

```
 securityContext:
    fsGroup: 2000
    runAsNonRoot: true
    runAsUser: 1000
    allowPrivilegeEscalation: false
```

  This is required when the pod security policy in kubernetes enforces containers to run with non root user. 

Following was the error shown in the pod logs, common to both opal-client and opal-server:

```
  Traceback (most recent call last):
    File "/usr/local/bin/gunicorn", line 33, in <module>
      sys.exit(load_entry_point('gunicorn==20.1.0', 'console_scripts', 'gunicorn')())
    File "/usr/local/bin/gunicorn", line 22, in importlib_load_entry_point
      for entry_point in distribution(dist_name).entry_points
    File "/usr/local/lib/python3.8/importlib/metadata.py", line 503, in distribution
      return Distribution.from_name(distribution_name)
    File "/usr/local/lib/python3.8/importlib/metadata.py", line 177, in from_name
      raise PackageNotFoundError(name)
  importlib.metadata.PackageNotFoundError: gunicorn
```

Switching the docker repository from `authorizon` to `permitio`, and changing the version to `0.3.1` did the trick.