### PR TITLE
Add SSH config options to template

### DIFF
--- a/templates/_utils.tpl
+++ b/templates/_utils.tpl
@@ -10,6 +10,10 @@
 {{ printf "%s-pgsql" .Release.Name }}
 {{- end -}}
 
+{{- define "opal.envSecretsName" -}}
+{{ printf "%s-env-secrets" .Release.Name }}
+{{- end -}}
+
 {{- define "opal.clientSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "opal.clientName" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -74,11 +74,24 @@ spec:
             - name: http
               containerPort: {{ .Values.server.port }}
               protocol: TCP
+          envFrom:
+          {{- if .Values.server.policyRepoSshKey }}
+          - secretRef:
+              name: {{ include "opal.envSecretsName" . }}
+          {{- end }}
           env:
             - name: OPAL_POLICY_REPO_URL
               value: {{ .Values.server.policyRepoUrl | quote }}
             - name: OPAL_POLICY_REPO_POLLING_INTERVAL
               value: {{ .Values.server.pollingInterval | quote }}
+            {{- if .Values.server.policyRepoClonePath }}
+            - name: OPAL_POLICY_REPO_CLONE_PATH
+              value: {{ .Values.server.policyRepoClonePath | quote }}
+            {{- end }}
+            {{- if .Values.server.policyRepoMainBranch }}
+            - name: OPAL_POLICY_REPO_MAIN_BRANCH
+              value: {{ .Values.server.policyRepoMainBranch | quote }}
+            {{- end }}
             - name: UVICORN_NUM_WORKERS
               value: {{ .Values.server.uvicornWorkers | quote }}
             - name: OPAL_DATA_CONFIG_SOURCES

--- a/templates/secret-envsecrets.yaml
+++ b/templates/secret-envsecrets.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.server.policyRepoSshKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "opal.envSecretsName" . }}
+type: Opague
+data:
+  OPAL_POLICY_REPO_SSH_KEY: {{ .Values.server.policyRepoSshKey | replace "\n" "_" | b64enc }}
+{{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -41,6 +41,15 @@
           "type": "string", "title": "policy repo url",
           "default":"https://github.com/authorizon/opal-example-policy-repo"
         },
+        "policyRepoSshKey": {
+          "type": ["null", "string"], "title": "policy SSH key","default": null
+        },
+        "policyRepoClonePath": {
+          "type": ["null", "string"], "title": "policy clone path","default": null
+        },
+        "policyRepoMainBranch": {
+          "type": ["null", "string"], "title": "policy main branch","default": null
+        },
         "pollingInterval": {
           "type": "integer", "title": "polling interval (sec)", "default": 30
         },

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,9 @@ imagePullSecrets: []
 server:
   port: 7002
   policyRepoUrl: "https://github.com/authorizon/opal-example-policy-repo"
+  policyRepoSshKey: null
+  policyRepoClonePath: null
+  policyRepoMainBranch: null
   pollingInterval: 30
   dataConfigSources:
     config:


### PR DESCRIPTION
Added 3 optional values to chart
 - policyRepoSshKey
 - policyRepoClonePath
 - policyRepoMainBranch

Which respectivly map to the following ENV
 - OPAL_POLICY_REPO_SSH_KEY
 - OPAL_POLICY_REPO_CLONE_PATH
 - OPAL_POLICY_REPO_MAIN_BRANCH

 Repo SSH Key is stored as a Kubernetes Secret