### PR TITLE
add support for mounting in files for opa startup data  cli argument

### DIFF
--- a/templates/cm.yaml
+++ b/templates/cm.yaml
@@ -11,3 +11,15 @@ data:
   rbac.rego: |
     {{- .Files.Get "test/e2e/rbac.rego" | nindent 4 }}
 {{- end }}
+---
+{{- if .Values.client.opaStartupData }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-startup-data
+data:
+  {{- range $name, $value := .Values.client.opaStartupData }}
+  {{ $name }}: |
+    {{ $value |  nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -20,6 +20,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.client.opaStartupData }}
+      volumes:
+        - name: opa-startup-data
+          configMap:
+            name: opa-startup-data
+            defaultMode: 0444
+      {{- end }}
       containers:
         - name: opal-client
           image: {{ printf "%s/permitio/opal-client:%s" .Values.imageRegistry .Chart.AppVersion | quote }}
@@ -43,6 +50,12 @@ spec:
             - name: {{ $name }}
               value: {{ $value | quote }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.client.opaStartupData }}
+          volumeMounts:
+            - mountPath: /opt/opa/startup-data
+              name: opa-startup-data
+              readOnly: true
           {{- end }}
           readinessProbe:
             httpGet:

--- a/values.schema.json
+++ b/values.schema.json
@@ -87,6 +87,9 @@
         },
         "extraEnv": {
           "type": "object", "title": "extra environment variables list", "default": null
+        },
+        "opaStartupData": {
+          "type": "object", "title": "client startup data for embedded opa", "default": null
         }
       }
     }


### PR DESCRIPTION
Quick way to add support for mounting in user-defined files into the client pod in order to add support for the [files](https://github.com/permitio/opal/blob/5b4729d4a62cf47454e79f48c498ff992aee078f/packages/opal-client/opal_client/opa/options.py#L61) option to work with this helm chart.