### PR TITLE
use OPAL v0.5.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ type: application
 icon: https://www.opal.ac/icons/icon-192x192.png
 version: 0.0.0 # actual chart version is managed by git tags
 kubeVersion: ">= 1.18.0-0"
-appVersion: 0.4.0
+appVersion: 0.5.0


### PR DESCRIPTION
Noticed that OPAL v0.5.0 was released the other week, would be great to bump the helm chart to use it!

I've tried it out locally by deploying the helm chart with v0.5.0 to minikube with these variables (as per [earlier issue](https://github.com/permitio/opal-helm-chart/issues/23)):
```
  extraEnv:
    "OPAL_DATA_UPDATER_ENABLED": 0
    "OPAL_OPA_HEALTH_CHECK_POLICY_ENABLED": 1
```

And all three pods show up as healthy. Not sure if there are any more test/adjustments needed for the bump to work properly?