### PR TITLE
Environment variables from Kubernetes Secrets

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -51,6 +51,13 @@ spec:
               value: {{ $value | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.client.secrets }}
+          envFrom:
+          {{- range $name := .Values.client.secrets }}
+            - secretRef:
+                name: {{ $name }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.client.opaStartupData }}
           volumeMounts:
             - mountPath: /opt/opa/startup-data

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -109,6 +109,13 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+          {{- if .Values.server.secrets }}
+          envFrom:
+          {{- range $name := .Values.server.secrets }}
+            - secretRef:
+                name: {{ $name }}
+          {{- end }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /healthcheck

--- a/values.schema.json
+++ b/values.schema.json
@@ -68,8 +68,13 @@
         },
         "extraEnv": {
           "type": "object", "title": "extra environment variables list", "default": null
+        },
+        "secrets": {
+          "type": "array",
+          "title": "name of a kubernetes secret from where to fetch secret environment variables.",
+          "default": null,
+          "items": { "type": "string" }
         }
-
       }
     },
     "client": {
@@ -90,6 +95,12 @@
         },
         "opaStartupData": {
           "type": "object", "title": "client startup data for embedded opa", "default": null
+        },
+        "secrets": {
+          "type": "array",
+          "title": "name of a kubernetes secret from where to fetch secret environment variables.",
+          "default": null,
+          "items": { "type": "string" }
         }
       }
     }


### PR DESCRIPTION
This PR adds the possibility to specify one or more kubernetes secrets from which to import environment variables from.

Would be happy to discuss implementation details if you have other ideas, but this approach seems relatively straight forward.

## Example:
Below is an example manifest that uses the external secrets operator to deploy a kubernetes secret `my-secret` with two variables from AWS SSM:

```yaml
apiVersion: external-secrets.io/v1alpha1
kind: ExternalSecret
metadata:
  name: my-external-secret
  namespace: my-namespace
spec:
  data:
  - remoteRef:
      key: /opal/my-test-secret
    secretKey: MY_TEST_SECRET
  - remoteRef:
      key: /opal/my-test-secret-2
    secretKey: MY_TEST_SECRET_2
  refreshInterval: 5m
  secretStoreRef:
    kind: ClusterSecretStore
    name: ssm
  target:
    creationPolicy: Owner
    name: my-secret
```


Then specify under client and/or server in values.yaml. All secrets in the kubernetes secret `my-secret` will be exposed as environment variables in the client container:

```yaml
client:
  ...
  secrets:
    - my-secret
```

This makes it easier to deal with secrets in a more secure way, where currently they need to be exposed when deploying the helm chart.