### PR TITLE
Make client healthy out of the box + other small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ The chart is published to public Helm repository, [hosted on GitHub itself](http
 Add Helm repository
 
 ```
-helm repo add opal https://permitio.github.io/opal-helm-chart
+helm repo add permitio https://permitio.github.io/opal-helm-chart
 helm repo update
 ```
 
 Install the latest version
 
 ```
-helm install --create-namespace -n opal-ns myopal opal/opal
+helm install --create-namespace -n opal-ns opal permitio/opal
 ```
 
 Search for all available versions
@@ -40,13 +40,13 @@ helm search repo opal --versions
 Install specific version (with default configuration):
 
 ```
-helm install --create-namespace -n opal-ns --version x.x.x myopal opal/opal
+helm install --create-namespace -n opal-ns --version x.x.x opal permitio/opal
 ```
 
 Install specific version (with custom configuration provided as YAML):
 
 ```
-helm install -f myvalues.yaml --create-namespace -n opal-ns --version x.x.x myopal opal/opal
+helm install -f myvalues.yaml --create-namespace -n opal-ns --version x.x.x opal permitio/opal
 ```
 
 `myvalues.yaml` must conform to the [json schema](https://raw.githubusercontent.com/permitio/opal-helm-chart/master/values.schema.json).
@@ -57,7 +57,7 @@ OPAL Client should populate embedded OPA instance with polices and data from con
 To validate it - one could create port-forwarding to OPAL client Pod. Port 8181 is the embedded OPA agent.
 
 ```
-kubectl port-forward -n opal-ns service/myopal-client 8181:8181
+kubectl port-forward -n opal-ns service/opal-client 8181:8181
 ```
 
 Then, open http://localhost:8181/v1/data/ in your browser to check OPA data document state.

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ This is not a comprehensive list, but includes the main variables you have to th
 | `server.extraEnv`                              | Extra configuration for opal-server (see [OPAL Docs](https://docs.opal.ac/tutorials/configure_opal))                                             |
 | `client.extraEnv`                              | Extra configuration for opal-server [OPAL Docs](https://docs.opal.ac/tutorials/configure_opal)                                                   |
 
-**Note:** If you don't use OPAL to manage policy data (`server.dataConfigSources` have no entries, No tracked json files in git repo) - Set `OPAL_DATA_UPDATER_ENABLED: False` in `client.extraEnv` so client won't report an unhealthy state.
+**Note:** If you leave `server.dataConfigSources` with no entries - The chart would automatically set `OPAL_DATA_UPDATER_ENABLED: False` in `client.extraEnv` so client won't report an unhealthy state.

--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -45,6 +45,10 @@ spec:
           {{- if .Values.server }}
             - name: OPAL_SERVER_URL
               value: {{ printf "http://%s:%v" (include "opal.serverName" .) .Values.server.port | quote }}
+            {{- if not (or (.Values.server.dataConfigSources.external_source_url) (len .Values.server.dataConfigSources.config.entries)) }}
+            - name: OPAL_DATA_UPDATER_ENABLED
+              value: "False"
+            {{- end }}
           {{- end }}
           {{- if .Values.client.extraEnv }}
           {{- range $name, $value := .Values.client.extraEnv }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -7,7 +7,9 @@
     "DataSourceEntry": {
       "type": "object", "title": "DataSourceEntry", "additionalProperties": false,
       "properties": {
-        "url": {"type": "string", "title": "url source to query for data"}
+        "url": {"type": "string", "title": "url source to query for data"},
+        "topics": {"type": "array", "title": "topics the data applies to", "items": { "type": "string" }},
+        "dst_path": {"type": "string", "title": "OPA data api path to store the document at"}
       }
     },
     "ServerDataSourceConfig": {

--- a/values.yaml
+++ b/values.yaml
@@ -30,12 +30,12 @@ server:
   broadcastPgsql: true
   uvicornWorkers: 4
   replicas: 1
-  extraEnv:
-    "CUSTOM_ENV_VAR": "VALUE"
+  extraEnv: {
+    # "CUSTOM_ENV_VAR": "VALUE"
+  }
 
 client:
   port: 7000
   opaPort: 8181
   replicas: 1
-  extraEnv:
-    "CUSTOM_ENV_VAR": "VALUE"
+  extraEnv: {}

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,20 @@ server:
   policyRepoMainBranch: null
   pollingInterval: 30
   dataConfigSources:
-    external_source_url: "https://your-api.com/path/to/api/endpoint"
+    # Option #1 - No data sources
+    config:
+      entries: []
+
+    # Option #2 - Dynamically get data sources
+    # external_source_url: "https://your-api.com/path/to/api/endpoint"
+
+    # Option #3 - Example static data sources (endpoint is empty by default)
+    # config:  
+    #   entries:
+    #   - url: http://opal-server:7002/policy-data
+    #     topics: ["policy_data"]
+    #     dst_path: "/static"
+
   broadcastUri: null
   broadcastPgsql: true
   uvicornWorkers: 4
@@ -26,4 +39,3 @@ client:
   replicas: 1
   extraEnv:
     "CUSTOM_ENV_VAR": "VALUE"
-


### PR DESCRIPTION
1. Disable DATA_UPDATER if no dataConfigSources (Client can't be healthy if data updater is enabled with there are no `dataConfigSources`)
2. Add missing fields in `dataConfigSources.config.entries`
3. Make `dataConfigSources` empty by default (dummy `external_source_url` was causing exceptions in client)
4. Add inline examples for other `dataConfigSources` configuration options.
5. Rename repo to `permitio` so full chart name would be `permitio/opal` instead of `opal`.
6. Use `opal` as release name instead of `myopal`.
7. Don't actually pass dummy variable to `extraEnv` - use inline commented example instead 