### PR TITLE
Add resources field to server and client template.

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -81,5 +81,9 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 10
             periodSeconds: 30
+          {{- if .Values.client.resources }}
+          resources:
+            {{- toYaml .Values.client.resources | nindent 12 }}
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -132,6 +132,9 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 10
             periodSeconds: 30
-
+          {{- if .Values.server.resources }}
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -90,6 +90,11 @@
           "title": "name of a kubernetes secret from where to fetch secret environment variables.",
           "default": null,
           "items": { "type": "string" }
+        },
+        "resources": {
+          "type": "object",
+          "title": "resources",
+          "default": null
         }
       }
     },
@@ -120,6 +125,11 @@
           "title": "name of a kubernetes secret from where to fetch secret environment variables.",
           "default": null,
           "items": { "type": "string" }
+        },
+        "resources": {
+          "type": "object",
+          "title": "resources",
+          "default": null
         }
       }
     }


### PR DESCRIPTION
This was discussed with @roekatz in the permitio slack.

It would be nice to be able to be able to specify resource requests and limits.

Now, you may add to `server` or `client` in `values.yaml`

```yaml
  resources:
    requests:
      cpu: 100m
      memory: 256Mi
    limits:
      cpu: 1000m
      memory: 1024Mi
```
