### PR TITLE
Split up image values to client, server and pgsql

### DIFF
--- a/templates/_utils.tpl
+++ b/templates/_utils.tpl
@@ -23,11 +23,15 @@
 {{- end -}}
 
 {{- define "opal.serverImage" -}}
-{{- printf "%s/permitio/opal-server" .Values.image.registry }}:{{  default .Chart.AppVersion .Values.image.tag }}
+{{- printf "%s/%s:%s" (default "docker.io" .Values.image.server.registry) (default "permitio/opal-server" .Values.image.server.repository) (default .Chart.AppVersion .Values.image.server.tag) }}
 {{- end -}}
 
 {{- define "opal.clientImage" -}}
-{{- printf "%s/permitio/opal-client" (default .Values.image.registry)  }}:{{  default .Chart.AppVersion .Values.image.tag }}
+{{- printf "%s/%s:%s" (default "docker.io" .Values.image.client.registry) (default "permitio/opal-client" .Values.image.client.repository) (default .Chart.AppVersion .Values.image.client.tag) }}
+{{- end -}}
+
+{{- define "opal.pgsqlImage" -}}
+{{- printf "%s/%s:%s" (default "docker.io" .Values.image.pgsql.registry) (default "postgres" .Values.image.pgsql.repository) (default "alpine" .Values.image.pgsql.tag) }}
 {{- end -}}
 
 {{- define "opal.envSecretsName" -}}

--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "opal.clientLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.client.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/deployment-pgsql.yaml
+++ b/templates/deployment-pgsql.yaml
@@ -16,9 +16,13 @@ spec:
       labels:
         {{- include "opal.pgsqlLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.image.client.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: pgsql
-          image: {{ printf "%s/postgres:alpine" .Values.postgresImageRegistry  | quote }}
+          image: {{ include "opal.pgsqlImage" . | quote }}
           imagePullPolicy: IfNotPresent
           ports:
             - name: pgsql

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "opal.serverLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.server.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -32,18 +32,88 @@
   },
 
   "type": "object", "required": ["image"],
-
   "properties": {
     "image": {
       "type": "object", "title": "image", "additionalProperties": false,
-      "required": ["registry"],
+      "required": ["server", "client", "pgsql"],
       "properties": {
-        "registry": { "type": "string", "default": "docker.io", "title": "docker image registry" },
-        "tag": { "type": "string", "title": "docker image tag" },
-        "pullPolicy": { "type": "string", "default": "IfNotPresent", "title": "docker image pull policy" }
+        "server": {
+          "type": "object", "title": "server", "additionalProperties": false,
+          "properties": {
+            "registry": {
+              "type": "string",
+              "default": "docker.io",
+              "title": "server docker image registry"
+            },
+            "repository": {
+              "type": "string",
+              "default": "permitio/opal-server",
+              "title": "server docker image repository"
+            },
+            "tag": {
+              "type": "string",
+              "title": "server docker image tag. defaults to chart appVersion"
+            },
+            "pullSecrets": {
+              "type": "array",
+              "default": [],
+              "title": "server docker image pull secrets"
+            }
+          }
+        },
+        "client": {
+          "type": "object", "title": "client", "additionalProperties": false,
+          "properties": {
+            "registry": {
+              "type": "string",
+              "default": "docker.io",
+              "title": "client docker image registry"
+            },
+            "repository": {
+              "type": "string",
+              "default": "permitio/opal-client",
+              "title": "client docker image repository"
+            },
+            "tag": {
+              "type": "string",
+              "title": "client docker image tag. defaults to chart appVersion"
+            },
+            "pullSecrets": {
+              "type": "array",
+              "default": [],
+              "title": "client docker image pull secrets"
+            }
+          }
+        },
+        "pgsql": {
+          "type": "object",
+          "title": "pgsql",
+          "additionalProperties": false,
+          "properties": {
+            "registry": {
+              "type": "string",
+              "default": "docker.io",
+              "title": "pgsql docker image registry"
+            },
+            "repository": {
+              "type": "string",
+              "default": "postgres",
+              "title": "pgsql docker image repository"
+            },
+            "tag": {
+              "type": "string",
+              "default": "alpine",
+              "title": "pgsql docker image tag"
+            },
+            "pullSecrets": {
+              "type": "array",
+              "default": [],
+              "title": "pgsql docker image pull secrets"
+            }
+          }
+        }
       }
     },
-    "postgresImageRegistry": { "type": "string", "default": "docker.io", "title": "docker registry for postgres image of the chart" },
     "server": {
       "type": ["null", "object"], "additionalProperties": false, "title": "opal server settings",
       "required": ["port", "policyRepoUrl", "pollingInterval", "dataConfigSources", "broadcastPgsql", "uvicornWorkers", "replicas"],

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,14 @@
 image:
-  registry: docker.io
-
-postgresImageRegistry: docker.io
-imagePullSecrets: [ ]
+  client:
+    registry: docker.io
+    repository: permitio/opal-client
+  server:
+    registry: docker.io
+    repository: permitio/opal-server
+  pgsql:
+    registry: docker.io
+    repository: postgres
+    tag: alpine
 
 server:
   port: 7002


### PR DESCRIPTION
This change mainly comes from a need of adding a custom FetchProvider (https://github.com/permitio/opal-fetcher-postgres). Doing so requires the user to be able to build and use a different client image.

In order to keep things consistent between all three images (server, client and pgsql) this change adds all three as subfield to the `image` field with the same subfields. There are appropriate defaults for all values such that the default values.yaml produce the same spec as before the change.

This commit also removes the pullPolicy field from the schema since it was not used anywhere.