### PR TITLE
Support setting dataSourceConfig through secrets or extraEnv

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -45,7 +45,7 @@ spec:
           {{- if .Values.server }}
             - name: OPAL_SERVER_URL
               value: {{ printf "http://%s:%v" (include "opal.serverName" .) .Values.server.port | quote }}
-            {{- if not (or (.Values.server.dataConfigSources.external_source_url) (.Values.server.dataConfigSources.config) ) }}
+            {{- if not (or (.Values.server.dataConfigSources.external_source_url) (.Values.server.dataConfigSources.config) (hasKey .Values.server.extraEnv "OPAL_DATA_UPDATER_ENABLED") ) }}
             - name: OPAL_DATA_UPDATER_ENABLED
               value: "False"
             {{- end }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -90,8 +90,10 @@ spec:
             {{- end }}
             - name: UVICORN_NUM_WORKERS
               value: {{ .Values.server.uvicornWorkers | quote }}
+            {{- if or .Values.server.dataConfigSources.config .Values.server.dataConfigSources.external_source_url }}
             - name: OPAL_DATA_CONFIG_SOURCES
               value: {{ .Values.server.dataConfigSources | toRawJson | squote }}
+            {{- end}}
             {{- if .Values.server.broadcastUri }}
             - name: OPAL_BROADCAST_URI
               value: {{ .Values.server.broadcastUri | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -32,6 +32,9 @@ server:
     #     topics: ["policy_data"]
     #     dst_path: "/static"
 
+    # Option #4 - Leave config empty and instead supply using the OPAL_DATA_CONFIG_SOURCES environment variable through env or secret
+    # config: null
+
   broadcastUri: null
   broadcastPgsql: true
   uvicornWorkers: 4


### PR DESCRIPTION
This PR contains two changes which are necessary in order to support passing dataSourceConfig as an env variable (through extraEnv or secrets) rather than via values.yaml.

1. Don't set env variable OPAL_DATA_CONFIG_SOURCES if config: null
2. Don't set env variable OPAL_DATA_UPDATER_ENABLED if it is passed as extraEnv

Before this change, running template with an empty datasources object

```
dataConfigSources:
	config: null
```

and also passing an extraEnv containing  `OPAL_DATA_UPDATER_ENABLED`
```
extraEnv: {
"OPAL_DATA_UPDATER_ENABLED": "true"
}
```

would yield two conflicting definitions of the `OPAL_DATA_UPDATER_ENABLED`:
```
➜ helm template . -f values.yaml | grep DATA_UPDATER -A 1
            - name: OPAL_DATA_UPDATER_ENABLED
              value: "False"
--
            - name: OPAL_DATA_UPDATER_ENABLED
              value: "true"
```

After this change, the value passed in extraEnv takes precedence
```
➜ helm template . -f values.yaml | grep DATA_UPDATER -A 1
            - name: OPAL_DATA_UPDATER_ENABLED
              value: "true"
```

Furthermore, with config: null we do not set `OPAL_DATA_CONFIG_SOURCES`, and assume that it will be passed through extraEnv or secret.