### PR TITLE
fix unlogical setting of OPAL_DATA_UPDATER_ENABLED

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -45,7 +45,7 @@ spec:
           {{- if .Values.server }}
             - name: OPAL_SERVER_URL
               value: {{ printf "http://%s:%v" (include "opal.serverName" .) .Values.server.port | quote }}
-            {{- if not (or (.Values.server.dataConfigSources.external_source_url) (.Values.server.dataConfigSources.config) (hasKey .Values.server.extraEnv "OPAL_DATA_UPDATER_ENABLED") ) }}
+            {{- if not (or (.Values.server.dataConfigSources.external_source_url) (.Values.server.dataConfigSources.config) (hasKey .Values.client.extraEnv "OPAL_DATA_UPDATER_ENABLED") ) }}
             - name: OPAL_DATA_UPDATER_ENABLED
               value: "False"
             {{- end }}


### PR DESCRIPTION
In my latest pr #51, I introduced functionality that would avoid setting the OPAL_DATA_UPDATER_ENABLED variable on the client if the variable was set on the server.

This is obviously a bit confusing. We should instead override the client env var on the client itself.