### PR TITLE
make image pull policy for server and client to be configurable

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: opal-client
           image: {{ include "opal.clientImage" . | quote }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.client.imagePullPolicy | default "IfNotPresent" | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.client.port }}

--- a/templates/deployment-server.yaml
+++ b/templates/deployment-server.yaml
@@ -62,7 +62,7 @@ spec:
       containers:
         - name: opal-server
           image: {{ include "opal.serverImage" . | quote }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.server.imagePullPolicy | default "IfNotPresent" | quote }}
           {{- if .Values.e2e }}
           volumeMounts:
             - mountPath: /opt/e2e/policy-repo-data

--- a/values.schema.json
+++ b/values.schema.json
@@ -169,6 +169,11 @@
           "type": "object",
           "title": "resources",
           "default": null
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "default": "IfNotPresent",
+          "title": "when kubelet should pull specified image"
         }
       }
     },
@@ -204,6 +209,11 @@
           "type": "object",
           "title": "resources",
           "default": null
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "default": "IfNotPresent",
+          "title": "when kubelet should pull specified image"
         }
       }
     }


### PR DESCRIPTION
- currently the `imagePullPolicy` for opal server and client is hardcoded to `IfNotPresent`
- changed it to be configurable 

Notes to reviewers:
- did not make the postgresql image pull policy to be configurable as i didn't see a use case for it, for server and client, the use case is if someone is building their own opal server/client images with latest tag, kubernetes wouldn't pull latest image as image pull policy is hard coded to `IfNotPresent`
- don't see anyone needing that for the postgresql image