### PR TITLE
feat: Enhance client deployment to receive custom server url

### DIFF
--- a/templates/deployment-client.yaml
+++ b/templates/deployment-client.yaml
@@ -43,8 +43,13 @@ spec:
             - name: UVICORN_NUM_WORKERS
               value: "1"
           {{- if .Values.server }}
+            {{- if .Values.client.serverUrl }}
+            - name: OPAL_SERVER_URL
+              value: {{ .Values.client.serverUrl | quote }}
+            {{- else }}
             - name: OPAL_SERVER_URL
               value: {{ printf "http://%s:%v" (include "opal.serverName" .) .Values.server.port | quote }}
+            {{- end}}
             {{- if not (or (.Values.server.dataConfigSources.external_source_url) (.Values.server.dataConfigSources.config) (hasKey .Values.client.extraEnv "OPAL_DATA_UPDATER_ENABLED") ) }}
             - name: OPAL_DATA_UPDATER_ENABLED
               value: "False"

--- a/values.schema.json
+++ b/values.schema.json
@@ -199,6 +199,10 @@
         "opaStartupData": {
           "type": "object", "title": "client startup data for embedded opa", "default": null
         },
+        "serverUrl": {
+          "type": "string",
+          "title": "opal server url for client to connect to"
+        },
         "secrets": {
           "type": "array",
           "title": "name of a kubernetes secret from where to fetch secret environment variables.",

--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,7 @@ server:
     # external_source_url: "https://your-api.com/path/to/api/endpoint"
 
     # Option #3 - Example static data sources (endpoint is empty by default)
-    # config:  
+    # config:
     #   entries:
     #   - url: http://opal-server:7002/policy-data
     #     topics: ["policy_data"]
@@ -47,4 +47,6 @@ client:
   port: 7000
   opaPort: 8181
   replicas: 1
+  # If you need to specify a custom hostname for the opal-sever, configure the serverUrl property
+  # serverUrl: http://custom-hostname-for-opal:opal-port
   extraEnv: {}


### PR DESCRIPTION
Provide the ability to configure OPAL_SERVER_URL from values.yaml file. If the property is not provided the default behaviour is applied