### PR TITLE
Add default values for pod scheduling fields

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -54,6 +54,10 @@ server:
   }
   securityContext: {}
   containerSecurityContext: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 client:
   port: 7000
@@ -64,6 +68,10 @@ client:
   extraEnv: {}
   securityContext: {}
   containerSecurityContext: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 postgresql:
   securityContext: {}


### PR DESCRIPTION
## Summary
- Add default values for `podLabels`, `nodeSelector`, `tolerations`, and `affinity` to both `server` and `client` sections in `values.yaml`
- Ensures these fields are discoverable via `helm show values`
- Maintains consistency with existing configurable fields in the chart

## Test plan
- [x] `helm lint` passes
- [x] `helm template` renders correctly with default values
- [x] `helm show values` displays the new fields
- [x] Overrides for all fields work as expected
- [x] OpenShift compatibility verified
- [x] No impact on pgsql deployment